### PR TITLE
send2trash issue hopefully resolved

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.1.2 (pre-release, 2019.06.23)
+- install_requires=['send2trash'] restored in setup.py. A try/except clause checks the module availability.
+
 v0.1.1 (pre-release, 2019.06.22)
 - "azote/main.py: corrected feh options" PR #8 by Head-on-a-Stick merged
 - some no longer needed print commands removed

--- a/azote/common.py
+++ b/azote/common.py
@@ -18,7 +18,7 @@ WARNING = 'warning'
 INFO = 'info'
 DEBUG = 'debug'
 
-env = {"wm": '', "i3ipc": False, "xrandr": False}
+env = {"wm": '', "i3ipc": False, "xrandr": False, "send2trash": False}
 sway = False
 
 lang = None             # dictionary "name": lang_string

--- a/azote/main.py
+++ b/azote/main.py
@@ -21,7 +21,14 @@ import common
 import gi
 import pkg_resources
 from PIL import Image
-from send2trash import send2trash
+
+try:
+    from send2trash import send2trash
+    common.env['send2trash'] = True
+except Exception as e:
+    common.env['send2trash'] = False
+    print('send2trash module not found', e)
+
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GdkPixbuf, Gdk
@@ -325,15 +332,16 @@ class GUI:
         common.feh_button.connect('clicked', self.on_feh_button)
         bottom_box.add(common.feh_button)
 
-        # Button to move to trash
-        common.trash_button = Gtk.Button()
-        img = Gtk.Image()
-        img.set_from_file('images/icon_trash.svg')
-        common.trash_button.set_image(img)
-        common.trash_button.set_tooltip_text(common.lang['move_to_trash'])
-        common.trash_button.set_sensitive(False)
-        common.trash_button.connect('clicked', self.on_trash_button)
-        bottom_box.add(common.trash_button)
+        if common.env['send2trash']:
+            # Button to move to trash
+            common.trash_button = Gtk.Button()
+            img = Gtk.Image()
+            img.set_from_file('images/icon_trash.svg')
+            common.trash_button.set_image(img)
+            common.trash_button.set_tooltip_text(common.lang['move_to_trash'])
+            common.trash_button.set_sensitive(False)
+            common.trash_button.connect('clicked', self.on_trash_button)
+            bottom_box.add(common.trash_button)
 
         # Label to display details of currently selected picture
         common.selected_picture_label = Gtk.Label()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='azote',
-    version='0.1.1',
+    version='0.1.2',
     description='Wallpaper manager for Sway, i3 and some other WMs',
     packages=['azote'],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     author='Piotr Miller',
     author_email='nwg.piotr@gmail.com',
     python_requires='>=3.5.0',
-    install_requires=[]
+    install_requires=['send2trash']
 )


### PR DESCRIPTION
- install_requires=['send2trash'] restored in setup.py. A try/except clause checks the module availability. If not found, the "Move to trash" button won't be shown. The python-send2trash package to be removed from dependencies.