### PR TITLE
Workaround to send2trash python module issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     author='Piotr Miller',
     author_email='nwg.piotr@gmail.com',
     python_requires='>=3.5.0',
-    install_requires=['send2trash']
+    install_requires=[]
 )


### PR DESCRIPTION
If the send2trash module not found, the "Move to trash" button won't be drawn. The python-send2trash dependency may be removed if the package unavailable.