### PR TITLE
v1.7.1

### DIFF
--- a/azote/common.py
+++ b/azote/common.py
@@ -48,6 +48,7 @@ log_file = ''           # ~/.azote/log.txt
 cmd_file = ''           # ~/.azote/command.sh
 config_home = ''        # $XDG_CONFIG_HOME or ~/.config/azote
 data_home = ''          # $XDG_DATA_HOME or ~/.local/share/azote
+data_migrated = False
 
 logging_enabled = True
 displays = None         # detected displays details

--- a/azote/tools.py
+++ b/azote/tools.py
@@ -567,7 +567,12 @@ class Settings(object):
         with open(self.file, 'rb') as input_data:
             settings = pickle.load(input_data)
 
-        self.src_path = settings.src_path  # holds selected path to source pictures
+        # Do not read if it's inside old folders (before data migration); save default value instead
+        if not settings.src_path == os.path.join(os.getenv('HOME'), '.azote/sample'):
+            self.src_path = settings.src_path
+        else:
+            save_needed = True
+
         try:
             self.sorting = settings.sorting  # 'new' 'old' 'az' 'za'
             log('Image sorting: {}'.format(self.sorting), common.INFO)


### PR DESCRIPTION
- Scale and crop an image to dual width or height of the primary display feature added.
- Data migrated to XGD-compliant locations.
- Scale & crop feature not working on X11 bug, previously fixed in 1.5.1, has been reintroduced accidentally. Fixed one more time.