### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,8 @@ Binary package `azote` available in the Void repository.
 
 ## Fedora
 
-For fedora-31:
+For fedora-31+:
 ```
-sudo dnf install azote
-```
-
-For others:
-```
-sudo dnf copr enable wef/azote
 sudo dnf install azote
 ```
 


### PR DESCRIPTION
azote is now in all the current official fedora repos - there's no longer any need for the temporary COPR repos