### PR TITLE
Simplify screen height measurement on sway #129

### DIFF
--- a/azote/common.py
+++ b/azote/common.py
@@ -20,6 +20,7 @@ DEBUG = 'debug'
 
 env = {}
 sway = False
+screen_h = None
 
 lang = None             # dictionary "name": lang_string
 

--- a/azote/main.py
+++ b/azote/main.py
@@ -1786,20 +1786,26 @@ def main():
 
     common.cols = len(common.displays) if len(common.displays) > common.settings.columns else common.settings.columns
 
-    # We want Azote to take all the possible screen height. Since Gdk.Screen.height is deprecated, we need to measure
-    # the current screen height in another way. `w` is a temporary window.
-    w = TransparentWindow()
-    if common.sway or common.env['wm'] == "i3":
-        w.fullscreen()  # .maximize() doesn't work as expected on sway
-    else:
-        w.maximize()
-    w.present()
-
     if common.settings.track_files:
         GLib.timeout_add_seconds(common.settings.tracking_interval_seconds, track_changes)
     if common.env['app_indicator']:
         common.indicator = Indicator()
-    GLib.timeout_add(common.settings.screen_measurement_delay, check_height_and_start, w)
+
+    # We want Azote to take all the possible screen height. Since Gdk.Screen.height is deprecated, we need to measure
+    # the current screen height in another way. `w` is a temporary window.
+    # If on sway, we've already detected the screen height in tools/check_displays() and stored it in common.screen_h
+    if not common.screen_h:
+        w = TransparentWindow()
+        if common.sway or common.env['wm'] == "i3":
+            w.fullscreen()  # .maximize() doesn't work as expected on sway
+        else:
+            w.maximize()
+        w.present()
+
+        GLib.timeout_add(common.settings.screen_measurement_delay, check_height_and_start, w)
+    else:
+        app = GUI(common.screen_h * 0.95)
+
     Gtk.main()
 
 

--- a/azote/tools.py
+++ b/azote/tools.py
@@ -89,6 +89,9 @@ def check_displays():
                                'height': output['rect']['height']}
                     displays.append(display)
                     log("Output found: {}".format(display), common.INFO)
+                if output['focused']:
+                    common.screen_h = output['rect']['height']
+                    print("Available screen height: {} px".format(int(common.screen_h * 0.95)))
 
             # sort displays list by x, y: from left to right, then from bottom to top
             displays = sorted(displays, key=lambda x: (x.get('x'), x.get('y')))


### PR DESCRIPTION
I realized that on sway there's no need to measure the screen height with the temporary window. The `"screen_measurement_delay": "delay_ms"` value from now on remains unused on sway. 