### PR TITLE
dist/azote: avoid usage of deprecated distutils module

### DIFF
--- a/dist/azote
+++ b/dist/azote
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-LIB=$( python3 -Ic "from distutils.sysconfig import get_python_lib; print(get_python_lib())" )
+LIB=$(python3 -Ic "from sysconfig import get_path; print(get_path('platlib'))")
 cd $LIB/azote
 exec /usr/bin/python3 main.py "$@"


### PR DESCRIPTION
The distutils module has been depecated in python 3.10.
Make use of sysconfig instead

Signed-off-by: Markus Volk <f_l_k@t-online.de>