### PR TITLE
Use purelib rather than platlib

### DIFF
--- a/dist/azote
+++ b/dist/azote
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-LIB=$(python3 -Ic "from sysconfig import get_path; print(get_path('platlib'))")
+LIB=$(python3 -Ic "from sysconfig import get_path; print(get_path('purelib'))")
 cd $LIB/azote
 exec /usr/bin/python3 main.py "$@"


### PR DESCRIPTION
azote is pure python with no compiled modules. setup.py installs correctly in /usr/lib/python3.10/site-packages but get_path('platlib') returns /usr/lib64 and fails to run.