### PR TITLE
fix generic display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ multi-headed setups in mind. Azote also includes several colour management tools
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/azote.svg)](https://repology.org/project/azote/versions)
 
-The program is confirmed to work on sway, Wayfire, i3, Openbox, Fluxbox and dwm window managers. Wayland support is
-limited to wlroots-based compositors. GNOME is not supported.
+The program, written primarily for sway, should work on all wlroots-based Wayland compositors, as well as on
+some X11 window managers. GNOME is not supported.
 
 Azote relies on numerous external packages. Some of them determine if the program is capable of working in a certain
 environment (sway / another wlroots-based compositor / X11). It's **up to the packager** which of them come preinstalled.
@@ -44,7 +44,7 @@ package already released for a certain Linux distribution. Some features rely on
 
 ### Main features:
 
-- works on Sway;
+- works on wlroots;
 - uses own thumbnails, 240x135px by default;
 - flips wallpapers horizontally;
 - splits wallpapers between 2 or more displays;
@@ -80,6 +80,13 @@ with:
 ```bash
 exec ~/.azotebg
 ```
+
+### Hyprland
+
+Add `exec-once = ~/.azotebg-hyprland` to your hyprland.conf. 
+
+Since v1.12.0, we no longer use common ~/.azotebg file on sway and Hyprland, as they don't detect generic 
+display names the same way.
 
 ### Wayfire
 

--- a/azote/tools.py
+++ b/azote/tools.py
@@ -83,12 +83,17 @@ def check_displays():
             outputs = json.loads(json_string)
             for output in outputs:
                 if output['active']:  # dunno WTF xroot-0 is: i3 returns such an output with "active":false
+                    g_name = output["make"] if output["make"] != "Unknown" else ""
+                    if output["model"] and output["model"] != "Unknown":
+                        g_name += " {}".format(output["model"])
+                    if output["serial"] and output["serial"] != "Unknown":
+                        g_name += " {}".format(output["serial"])
                     display = {'name': output['name'],
                                'x': output['rect']['x'],
                                'y': output['rect']['y'],
                                'width': output['rect']['width'],
                                'height': output['rect']['height'],
-                               'generic-name': "{} {} {}".format(output["make"], output["model"], output["serial"])}
+                               'generic-name': g_name}
                     displays.append(display)
                     log("Output found: {}".format(display), common.INFO)
                 try:
@@ -120,12 +125,17 @@ def check_displays():
         displays = []
         clients = json.loads(output)
         for c in clients:
+            g_name = c["make"] if c["make"] else ""
+            if c["model"]:
+                g_name += " {}".format(c["model"])
+            if c["serial"]:
+                g_name += " {}".format(c["serial"])
             display = {'name': c['name'],
                        'x': c['x'],
                        'y': c['y'],
                        'width': c['width'],
                        'height': c['height'],
-                       'generic-name': "{} {} {}".format(c["make"], c["model"], c["serial"])}
+                       'generic-name': g_name}
             displays.append(display)
             log("Output found: {}".format(display), common.INFO)
 
@@ -353,8 +363,11 @@ def set_env(__version__, lang_from_args=None):
     if not os.path.isdir(common.thumb_dir):
         os.mkdir(common.thumb_dir)
 
-    # command file
-    common.cmd_file = os.path.join(os.getenv("HOME"), ".azotebg")
+    # command file; let's use separate file name for Hyprland, as generic display names may be different
+    if os.getenv("HYPRLAND_INSTANCE_SIGNATURE"):
+        common.cmd_file = os.path.join(os.getenv("HOME"), ".azotebg-hyprland")
+    else:
+        common.cmd_file = os.path.join(os.getenv("HOME"), ".azotebg")
 
     # temporary folder
     common.tmp_dir = os.path.join(common.data_home, "temp")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='azote',
-    version='1.11.1',
+    version='1.12.0',
     description='Wallpaper manager for sway and some other WMs',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- fixed generic name creation when the serial number field is empty / "none";
- as the serial numbers returned by sway and Hyprland may be different for some reason, from now on we use the new `~/.azotebg-hyprland` setter script on Hyprland. **Edit your `hyprland.conf`**.