### PR TITLE
Fix for non-standard thumbnails

### DIFF
--- a/azote/tools.py
+++ b/azote/tools.py
@@ -687,7 +687,7 @@ def expand_img(image):
         # border = (border_h, border_v, border_h, border_v)
         # return ImageOps.expand(image, border=border)
         # Let's add checkered background instead of the black one
-        background = Image.open('images/squares.jpg')
+        background = Image.open(os.path.join(dir_name, 'images/squares.jpg'))
         background = background.resize(common.settings.thumb_size, Image.LANCZOS)
         background.paste(image, (border_h, border_v))
         return background

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+install -Dm 644 -t /usr/share/pixmaps dist/azote.svg
+install -Dm 644 -t /usr/share/azote dist/indicator*.png
+install -Dm 644 -t /usr/share/applications dist/azote.desktop
+install -Dm 644 -t /usr/share/doc/azote README.md
+
+python -m build --wheel --no-isolation
+python -m installer dist/*.whl

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+rm -f /usr/bin/azote
+
 install -Dm 644 -t /usr/share/pixmaps dist/azote.svg
 install -Dm 644 -t /usr/share/azote dist/indicator*.png
 install -Dm 644 -t /usr/share/applications dist/azote.desktop

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
 
+PROGRAM_NAME="azote"
+MODULE_NAME="azote"
+SITE_PACKAGES="$(python3 -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")"
+PATTERN="$SITE_PACKAGES/$MODULE_NAME*"
+
+# Remove from site_packages
+for path in $PATTERN; do
+    if [ -e "$path" ]; then
+        echo "Removing $path"
+        rm -r "$path"
+    fi
+done
+
 rm -f /usr/bin/azote
 
-install -Dm 644 -t /usr/share/pixmaps dist/azote.svg
-install -Dm 644 -t /usr/share/azote dist/indicator*.png
-install -Dm 644 -t /usr/share/applications dist/azote.desktop
-install -Dm 644 -t /usr/share/doc/azote README.md
+install -Dm 644 -t /usr/share/pixmaps "dist/$PROGRAM_NAME.svg"
+install -Dm 644 -t "/usr/share/$PROGRAM_NAME" dist/indicator*.png
+install -Dm 644 -t /usr/share/applications "dist/$PROGRAM_NAME.desktop"
+install -Dm 644 -t "/usr/share/doc/$PROGRAM_NAME" README.md
 
 python -m build --wheel --no-isolation
 python -m installer dist/*.whl

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='azote',
-    version='1.13.0',
+    version='1.13.1',
     description='Wallpaper manager for sway and some other WMs',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Fixed path to the helper image used when creating a thumbnail for images with non-standard aspect ratios. Closes #197.