### PR TITLE
Add support for JPEG XL images to Pillow through pillow-jxl-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ exec dwm
 
 ### Optional dependencies:
 
+- `python-pillow-jxl-plugin`: for JPEG XL support in Pillow
 - `imagemagick`: for screen color picker in every environment
 - `grim`, `slurp`: for screen color picker on sway / wlroots
 - `maim`, `slop`: for screen color picker on X11

--- a/azote/colorthief.py
+++ b/azote/colorthief.py
@@ -12,6 +12,11 @@ __version__ = '0.2.1'
 
 import math
 
+# Attempt to load in JXL support
+try:
+     import pillow_jxl
+except ImportError:
+     pass
 from PIL import Image
 
 

--- a/azote/common.py
+++ b/azote/common.py
@@ -37,7 +37,7 @@ apply_to_all_button = None
 
 cols = 3                # number of columns in pictures preview
 
-allowed_file_types = ['jpg', 'jpeg', 'png', 'webp']
+allowed_file_types = ['jpg', 'jpeg', 'jxl', 'png', 'webp']
 associations = None     # dictionary {'extension": [program1, program2, program3, ...]}
 
 app_dir = ''            # ~/.azote

--- a/azote/main.py
+++ b/azote/main.py
@@ -14,9 +14,17 @@ import os
 import sys
 import subprocess
 import stat
+
 import gi
 import cairo
+
+# Attempt to load in JXL support
+try:
+     import pillow_jxl
+except ImportError:
+     pass
 from PIL import Image
+
 from azote import common
 
 # send2trash module may or may not be available

--- a/azote/tools.py
+++ b/azote/tools.py
@@ -14,13 +14,19 @@ import os
 import glob
 import hashlib
 import logging
-from PIL import Image
 import pickle
 import subprocess
 import sys
 import shutil
 
 import json
+
+# Attempt to load in JXL support
+try:
+     import pillow_jxl
+except ImportError:
+     pass
+from PIL import Image
 
 import gi
 


### PR DESCRIPTION
Pillow does not support JPEG XL images out of the box, but there is a plugin to support this. Since anything using gdk-pixbuf can also optionally support JPEG XL, we should also optionally support it for thumbnail generation too.